### PR TITLE
Adding global property so that it's assigned to the global o-assets-path...

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -56,7 +56,7 @@ $o-assets-paths-map: () !default;
 }
 
 @mixin oAssetsSetModulePaths ($path-map) {
-    $o-assets-paths-map: map-merge($o-assets-paths-map, $path-map);
+    $o-assets-paths-map: map-merge($o-assets-paths-map, $path-map) !global;
 }
 
 


### PR DESCRIPTION
...-map variable.

We were getting this SASS warning:

Assigning to global variable "$o-assets-paths-map" by default is deprecated.
In future versions of Sass, this will create a new local variable.
If you want to assign to the global variable, use "$o-assets-paths-map: map-merge($o-assets-paths-map, $path-map) !global" instead.
Note that this will be incompatible with Sass 3.2.

We're using Sass 3.3+, so I think it should be fine. We might need to update the build service change though so it does it like this. Or at least add the global flag when assigning the o-assets-paths-map variable.
