### PR TITLE
Update to be ESLint compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
-language: node_js
 sudo: false
+language: node_js
 node_js:
-  - "0.10"
+  - "4"
 before_install:
-  - npm install -g Financial-Times/origami-build-tools#node-0.10
+  - npm install -g Financial-Times/origami-build-tools#node4
   - obt install
 script:
   - obt test

--- a/main.js
+++ b/main.js
@@ -1,8 +1,6 @@
-'use strict';
-
-var globalPrefix = '/bower_components/';
-var moduleVersions = {};
-var modulePaths = {};
+let globalPrefix = '/bower_components/';
+const moduleVersions = {};
+const modulePaths = {};
 
 function trim(s) {
 	return s.replace(/^\/+/, '').replace(/\/+$/, '');
@@ -17,7 +15,7 @@ module.exports = {
 	},
 	// left in for backwards compatibility but shouldn't be needed hereonin
 	setModuleVersions: function(map) {
-		for (var i in map) {
+		for (const i in map) {
 			if (i) {
 				moduleVersions[i] = trim(map[i]);
 			}
@@ -25,7 +23,7 @@ module.exports = {
 		return this;
 	},
 	setModulePaths: function(map) {
-		for (var i in map) {
+		for (const i in map) {
 			if (i) {
 				modulePaths[i] = trim(map[i]);
 			}
@@ -33,7 +31,7 @@ module.exports = {
 		return this;
 	},
 	resolve: function(path, modulename) {
-		var fullpath = trim(path);
+		let fullpath = trim(path);
 
 		if (typeof modulePaths[modulename] !== 'undefined') {
 			fullpath = modulePaths[modulename] + '/' + fullpath;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "test": "obt build --sass=test/test.scss --buildCss=test.css && ./node_modules/mocha/bin/mocha test/assets.test.js --compilers js:babel/register"
   },
   "devDependencies": {
-    "babel": "^4.7.16",
+    "babel": "^5.8.21",
     "expect.js": "^0.3.1",
     "mocha": "^2.2.1"
   }

--- a/test/assets.test.js
+++ b/test/assets.test.js
@@ -1,6 +1,5 @@
 /*jslint node: true */
-/*global describe, it, expect*/
-'use strict';
+/*global describe, it*/
 
 import {readFileSync} from 'fs';
 import expect from 'expect.js';
@@ -8,7 +7,7 @@ import oAssets from '../main';
 
 describe('o-assets', () => {
 	it('should pass CSS tests', () => {
-		var css = readFileSync(require('path').join(process.cwd(), 'build/test.css'), 'utf8');
+		const css = readFileSync(require('path').join(process.cwd(), 'build/test.css'), 'utf8');
 		expect(css).to.contain('Failed: 0');
 	});
 
@@ -18,7 +17,7 @@ describe('o-assets', () => {
 	});
 
 	it('#setGlobalPathPrefix', () => {
-		var chainedoAssets = oAssets.setGlobalPathPrefix();
+		const chainedoAssets = oAssets.setGlobalPathPrefix();
 		expect(chainedoAssets).to.be(oAssets);
 		expect(oAssets.resolve('/img/logo.png', 'module1')).to.be('/bower_components/module1/img/logo.png');
 
@@ -27,7 +26,7 @@ describe('o-assets', () => {
 	});
 
 	it('#setModulePaths', () => {
-		var chainedoAssets = oAssets.setModulePaths({
+		const chainedoAssets = oAssets.setModulePaths({
 			module1: 'module1modified',
 			module2: '/module2modified/',
 			module4: 'module4modified@~1.0.0'

--- a/test/assets.test.js
+++ b/test/assets.test.js
@@ -1,4 +1,4 @@
-/*jslint node: true */
+/*eslint-env node*/
 /*global describe, it*/
 
 import {readFileSync} from 'fs';

--- a/test/test.scss
+++ b/test/test.scss
@@ -7,7 +7,7 @@ $bc-setting-warnings: false;
 @include runner-start;
 
 @include oAssetsSetModulePaths((
-	module2: /assets/module2
+	'module2': '/assets/module2'
 ));
 
 @include describe("oAssets") {


### PR DESCRIPTION
DO NOT MERGE until Origami Build Tools 4 is final.

Update syntax to ES6. Babel was causing errors on the version provided.