### PR TITLE
Revert "use ESM insteadof CJS"

### DIFF
--- a/main.js
+++ b/main.js
@@ -6,7 +6,7 @@ function trim(s) {
 	return s.replace(/^\/+/, '').replace(/\/+$/, '');
 }
 
-const oAssets = {
+module.exports = {
 	setGlobalPathPrefix: function(newprefix) {
 		if (typeof newprefix !== 'undefined') {
 			globalPrefix = newprefix;
@@ -46,6 +46,3 @@ const oAssets = {
 		return fullpath;
 	}
 };
-
-export default oAssets;
-export { oAssets };

--- a/test/assets.test.js
+++ b/test/assets.test.js
@@ -1,8 +1,7 @@
 /* eslint-env mocha */
 
-import proclaim from 'proclaim';
-
-import oAssets from '../main';
+const proclaim = require('proclaim');
+const oAssets = require('../main');
 
 describe('o-assets', () => {
 	it('#resolve', () => {


### PR DESCRIPTION
Reverts Financial-Times/o-assets#37

Looks like this has broken a few components in production, including o-comments and o-tooltip. I'm reverting for now.