### PR TITLE
Add the origami-labels GitHub Action

### DIFF
--- a/.github/workflows/sync-repo-labels.yml
+++ b/.github/workflows/sync-repo-labels.yml
@@ -1,0 +1,10 @@
+
+on: [issues, pull_request]
+jobs:
+  sync-labels:
+    runs-on: ubuntu-latest
+    name: Sync repository labels
+    steps:
+      - uses: Financial-Times/origami-labels@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This syncs repo labels with a standard Origami set.\nSee https://github.com/Financial-Times/origami/issues/24 for more information.