### PR TITLE
Stop using magic webpack imports

### DIFF
--- a/test/assets.test.js
+++ b/test/assets.test.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
+/* global proclaim */
 
-const proclaim = require('proclaim');
 const oAssets = require('../main');
 
 describe('o-assets', () => {


### PR DESCRIPTION
Stop using the magic imports for proclaim and sinon and pull them from the global because that's where Karma has added them. This is required for obt v10 to be released.