### PR TITLE
Deprecate o-assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # o-assets [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](#licence)
 
+_Deprecated._ `o-assets` does not support Origami components delivered via npm or version 2 of the Origami specification.
+
 This component provides Sass and JavaScript utilities for reliably building paths to a component's static assets, such as CSS background images, fonts and JSON data files. This is needed because the URL path to load these assets will vary depending on how a product developer chooses to integrate the Origami component into their website.
 
 - [Overview](#overview)

--- a/origami.json
+++ b/origami.json
@@ -9,5 +9,5 @@
 		"email": "origami.support@ft.com",
 		"slack": "financialtimes/origami-support"
 	},
-	"supportStatus": "active"
+	"supportStatus": "deprecated"
 }


### PR DESCRIPTION
o-assets won't support v2 of the Origami specification. There is
a proposal for handling unique component assets here:
https://github.com/Financial-Times/origami/pull/102